### PR TITLE
feat: Enable 192kHz spectrogram display

### DIFF
--- a/spectrogram/src/javascripts/UI/player.js
+++ b/spectrogram/src/javascripts/UI/player.js
@@ -24,7 +24,9 @@ function Player() {
 	var analyser = context.createAnalyser();
 	//analyser.fftSize = 2048 * 2 * 2
 	// analyser.fftSize = (window.isMobile)? 2048 : 8192;
-	analyser.fftSize = (window.isMobile)?1024 : 2048;
+	// analyser.fftSize = (window.isMobile)?1024 : 2048;
+	analyser.fftSize = 16384; // Increased FFT size for better high-frequency resolution
+	analyser.minDecibels = -120; // Adjusted minDecibels for wider dynamic range
 	analyser.smoothingTimeConstant = 0;
 
 	// Create a mix.

--- a/spectrogram/src/javascripts/UI/spectrogram.js
+++ b/spectrogram/src/javascripts/UI/spectrogram.js
@@ -85,7 +85,7 @@ var spec3D = {
 
   attached: function() {
     console.log('spectrogram-3d attached');
-    Util.setLogScale(20, 20, 20000, 20000);
+    Util.setLogScale(20, 20, 96000, 96000);
     spec3D.onResize_();
     spec3D.init_();
 
@@ -186,6 +186,7 @@ var spec3D = {
     ctx.font = '14px Roboto';
     ctx.textAlign = 'right';
     ctx.textBaseline = 'middle';
+    ctx.fillText('96,000 Hz -', x, canvas.height - spec3D.freqToY(96000));
     ctx.fillText('20,000 Hz -', x, canvas.height - spec3D.freqToY(20000));
     ctx.fillText('2,000 Hz -', x, canvas.height - spec3D.freqToY(2000));
     ctx.fillText('200 Hz -', x, canvas.height - spec3D.freqToY(200));
@@ -200,7 +201,7 @@ var spec3D = {
    * TODO(smus): Make this work properly with WebGL.
    */
   freqStart: 20,
-  freqEnd: 20000,
+  freqEnd: 96000,
   padding: 30,
   yToFreq: function(y) {
     var padding = spec3D.padding;


### PR DESCRIPTION
This change modifies the spectrogram to support audio files with sample rates up to 192kHz and display frequencies up to 96kHz.

Key changes:
- Updated frequency scaling in UI/spectrogram.js to range up to 96kHz.
- Modified the legend to reflect the new maximum frequency.
- Increased AnalyserNode.fftSize in UI/player.js to 16384 for better frequency resolution at higher sample rates.
- Adjusted AnalyserNode.minDecibels to -120dB to capture a wider dynamic range, making quieter high-frequency content more visible.